### PR TITLE
Fix: Some ui quick wins

### DIFF
--- a/components/ConversionPanel.js
+++ b/components/ConversionPanel.js
@@ -201,6 +201,15 @@ export default class ConversionPanel extends PureComponent {
       scrollbarStyle: null
     };
 
+    // hide success footer bannner after 2 seconds. Let other types be visible until fixed.
+    clearTimeout(this.footerTimeout);
+    if (infoType === "success") {
+      this.footerTimeout = setTimeout(() => this.setState({
+        info: "",
+        infoType: ""
+      }), 2000);
+    }
+
     return (
       <div className="wrapper">
         <style jsx>{`

--- a/components/ConversionPanel.js
+++ b/components/ConversionPanel.js
@@ -450,9 +450,13 @@ export default class ConversionPanel extends PureComponent {
             </div>
           </div>
         </div>
-        <div className={`footer${infoType ? " has-" + infoType : ""}`}>
-          <span className="info">{info}</span>
-        </div>
+        {
+          infoType !== "" && (
+            <div className={`footer has-${infoType}`}>
+              <span className="info">{info}</span>
+            </div>
+          )
+        }
       </div>
     );
   }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -171,9 +171,8 @@ export default class Layout extends PureComponent {
           }
 
           .nav {
-            padding: 20px 0;
             flex: 1;
-            overflow-y: scroll;
+            overflow-y: auto;
           }
 
           .twitter {
@@ -187,16 +186,10 @@ export default class Layout extends PureComponent {
           }
 
           .footer {
-            height: 70px;
+            padding: 10px 5px;
             text-align: center;
             color: #fff;
             font-family: "Lato", sans-serif;
-          }
-
-          .footer svg {
-            height: 36px;
-            width: 30px;
-            color: #fff;
           }
 
           .badge {
@@ -296,9 +289,8 @@ export default class Layout extends PureComponent {
           <div className="logo">
             <Logo />
           </div>
+          <div className="info">Use Ctrl/Cmd + P for quick search</div>
           <div className="nav">
-            <div className="info">Use Ctrl/Cmd + P for quick search</div>
-
             <Collapse
               onChange={this.onChange}
               accordion
@@ -333,7 +325,7 @@ export default class Layout extends PureComponent {
           </div>
 
           <div className="footer">
-            <br />Created by{" "}
+            Created by{" "}
             <a
               target="_blank"
               className="twitter"


### PR DESCRIPTION
* Sidebar scroll to only show when needed.
    * When scrollbar comes up only show around collapsible areas.
* Use padding and not height for author name. It looks nice and centered.
* Only show bottom footer if their is information to display.
    * For success type banner, hide it after 2 seconds.
    * For all other types, show until fixed.